### PR TITLE
Use symbols for all offlineimap process status options

### DIFF
--- a/offlineimap.el
+++ b/offlineimap.el
@@ -65,11 +65,13 @@ action as a text in color instead of a single symbol."
   :type '(choice (const :tag "Symbol" symbol)
                  (const :tag "Action text" text)))
 
-(defcustom offlineimap-mode-line-symbol "✉"
-  "Symbol used to display OfflineIMAP status in mode-line.
-This is used when `offlineimap-mode-line-style' is set to 'symbol."
+(defcustom offlineimap-mode-line-symbols '((run . "✉")
+                                           (exit . "×"))
+  "Symbols used to display OfflineIMAP status in mode-line.
+These are used when `offlineimap-mode-line-style' is set to
+`symbol'."
   :group 'offlineimap
-  :type 'string)
+  :type '(repeat (cons :tag "Use symbol for signal" (symbol :tag "Signal") (string :tag "Symbol"))))
 
 (defcustom offlineimap-mode-line-text "OfflineIMAP: "
   "Text used to display OfflineIMAP status in mode-line."
@@ -204,8 +206,11 @@ This is used when `offlineimap-mode-line-style' is set to 'symbol."
                          (offlineimap-propertize-face msg-type action
                                                       (if (eq offlineimap-mode-line-style 'text)
                                                           action
-                                                        offlineimap-mode-line-symbol)))
-                    (propertize (symbol-name status) 'face 'offlineimap-error-face)))
+                                                        (cdr (assoc 'run offlineimap-mode-line-symbols)))))
+                     (propertize (or (and (eq offlineimap-mode-line-style 'symbol)
+                                          (cdr (assoc status offlineimap-mode-line-symbols)))
+                                     (symbol-name status))
+                                 'face 'offlineimap-error-face)))
                  "]")
          'mouse-face 'mode-line-highlight
          'help-echo "mouse-2: Go to OfflineIMAP buffer"

--- a/offlineimap.el
+++ b/offlineimap.el
@@ -66,7 +66,8 @@ action as a text in color instead of a single symbol."
                  (const :tag "Action text" text)))
 
 (defcustom offlineimap-mode-line-symbols '((run . "✉")
-                                           (exit . "×"))
+                                           (exit . "×")
+                                           (signal . "⚑"))
   "Symbols used to display OfflineIMAP status in mode-line.
 These are used when `offlineimap-mode-line-style' is set to
 `symbol'."

--- a/offlineimap.el
+++ b/offlineimap.el
@@ -66,13 +66,19 @@ action as a text in color instead of a single symbol."
                  (const :tag "Action text" text)))
 
 (defcustom offlineimap-mode-line-symbols '((run . "✉")
-                                           (exit . "×")
-                                           (signal . "⚑"))
+                                           (stop .  "↻")
+                                           (exit .  "×")
+                                           (signal . "⚑")
+                                           (open .  "⊙")
+                                           (listen . "⌥")
+                                           (closed . "●")
+                                           (connect . "…")
+                                           (failed . "⌁"))
   "Symbols used to display OfflineIMAP status in mode-line.
 These are used when `offlineimap-mode-line-style' is set to
 `symbol'."
   :group 'offlineimap
-  :type '(repeat (cons :tag "Use symbol for signal" (symbol :tag "Signal") (string :tag "Symbol"))))
+  :type '(repeat (cons :tag "Mode line symbol" (symbol :tag "Signal") (string :tag "Symbol"))))
 
 (defcustom offlineimap-mode-line-text "OfflineIMAP: "
   "Text used to display OfflineIMAP status in mode-line."


### PR DESCRIPTION
This change introduces the ability to use symbols for all statuses of the offlineimap process, not just for the status `run`.

If `offlineimap-mode-line-style` is set to `text`, nothing will change. If it's set to `symbol`, all signals will be displayed as a symbol (for which a proper Unicode font is required). The symbols used are customizable.